### PR TITLE
Improve room names.

### DIFF
--- a/matrix/bar_items.py
+++ b/matrix/bar_items.py
@@ -51,7 +51,7 @@ def matrix_bar_item_name(data, item, window, buffer, extra_info):
 
             return "{color}{name}".format(
                 color=W.color(color),
-                name=room.display_name())
+                name=room.display_name(server.user_id))
 
         elif buffer == server.server_buffer:
             color = ("status_name_ssl"

--- a/matrix/bar_items.py
+++ b/matrix/bar_items.py
@@ -49,7 +49,9 @@ def matrix_bar_item_name(data, item, window, buffer, extra_info):
 
             room = server.rooms[room_id]
 
-            return "{color}{name}".format(color=W.color(color), name=room.alias)
+            return "{color}{name}".format(
+                color=W.color(color),
+                name=room.display_name())
 
         elif buffer == server.server_buffer:
             color = ("status_name_ssl"

--- a/matrix/commands.py
+++ b/matrix/commands.py
@@ -918,13 +918,18 @@ def matrix_command_topic_cb(data, buffer, command):
                 if not room.topic:
                     return W.WEECHAT_RC_OK
 
-                message = ("{prefix}Topic for {color}{room}{ncolor} is "
-                           "\"{topic}\"").format(
-                               prefix=W.prefix("network"),
-                               color=W.color("chat_buffer"),
-                               ncolor=W.color("reset"),
-                               room=room.alias,
-                               topic=room.topic)
+                if room.is_named():
+                    message = ('{prefix}Topic for {color}{room}{ncolor} is '
+                               '"{topic}"').format(
+                                   prefix=W.prefix("network"),
+                                   color=W.color("chat_buffer"),
+                                   ncolor=W.color("reset"),
+                                   room=room.named_room_name(),
+                                   topic=room.topic)
+                else:
+                    message = ('{prefix}Topic is "{topic}"').format(
+                        prefix=W.prefix("network"),
+                        topic=room.topic)
 
                 date = int(time.time())
                 topic_date = room.topic_date.strftime("%a, %d %b %Y "

--- a/matrix/rooms.py
+++ b/matrix/rooms.py
@@ -706,15 +706,22 @@ class RoomTopicEvent(RoomEvent):
             nick_color=W.color(color_name), user=nick, ncolor=W.color("reset"))
 
         # TODO print old topic if configured so
-        message = ("{prefix}{nick} has changed "
-                   "the topic for {chan_color}{room}{ncolor} "
-                   "to \"{topic}\"").format(
-                       prefix=W.prefix("network"),
-                       nick=author,
-                       chan_color=W.color("chat_channel"),
-                       ncolor=W.color("reset"),
-                       room=room.display_name(server.user_id),
-                       topic=topic)
+        if room.is_named():
+            message = ("{prefix}{nick} has changed "
+                       "the topic for {chan_color}{room}{ncolor} "
+                       "to \"{topic}\"").format(
+                           prefix=W.prefix("network"),
+                           nick=author,
+                           chan_color=W.color("chat_channel"),
+                           ncolor=W.color("reset"),
+                           room=room.named_room_name(),
+                           topic=topic)
+        else:
+            message = ('{prefix}{nick} has changed the topic to '
+                       '"{topic}"').format(
+                           prefix=W.prefix("network"),
+                           nick=author,
+                           topic=topic)
 
         tags = ["matrix_topic", "log3", "matrix_id_{}".format(self.event_id)]
 


### PR DESCRIPTION
We now track the room ID, the canonical alias and the name of the room
separately. Only the room ID is guaranteed to be set (instead of `None`).

Additionally, a number of methods were added to MatrixRoom to assist in
calculating the name of the room and determining whether it is a named room
or an ad hoc "group" of users.

The most important method is `MatrixRoom.display_name` which calculates the
display name of the room (roughly) according to section 11.2.2.5[*] of the
Matrix v0.3.0 spec.

[*] https://matrix.org/docs/spec/client_server/r0.3.0.html#id268