### PR TITLE
Handle combination of strikethrough and other attributes.

### DIFF
--- a/matrix/colors.py
+++ b/matrix/colors.py
@@ -288,6 +288,14 @@ class Formatted():
             text = formatted_string.text
             attributes = formatted_string.attributes
 
+            # We need to handle strikethrough first, since doing
+            # a strikethrough followed by other attributes succeeds in the
+            # terminal, but doing it the other way around results in garbage.
+            if 'strikethrough' in attributes:
+                text = add_attribute(text, 'strikethrough',
+                                     attributes['strikethrough'])
+                attributes.pop('strikethrough')
+
             for key, value in attributes.items():
                 text = add_attribute(text, key, value)
             return text

--- a/matrix/rooms.py
+++ b/matrix/rooms.py
@@ -33,6 +33,8 @@ from matrix.utils import (
     get_prefix_for_level, sanitize_power_level, string_strikethrough,
     line_pointer_and_tags_from_event, sender_to_prefix_and_color)
 
+from weechat import string_remove_color
+
 PowerLevel = namedtuple('PowerLevel', ['user', 'level'])
 
 
@@ -815,7 +817,8 @@ class RoomRedactionEvent(RoomEvent):
         new_message = ""
 
         if OPTIONS.redaction_type == RedactType.STRIKETHROUGH:
-            new_message = string_strikethrough(message)
+            plaintext_msg = string_remove_color(message, '')
+            new_message = string_strikethrough(plaintext_msg)
         elif OPTIONS.redaction_type == RedactType.NOTICE:
             new_message = message
         elif OPTIONS.redaction_type == RedactType.DELETE:

--- a/matrix/rooms.py
+++ b/matrix/rooms.py
@@ -33,8 +33,6 @@ from matrix.utils import (
     get_prefix_for_level, sanitize_power_level, string_strikethrough,
     line_pointer_and_tags_from_event, sender_to_prefix_and_color)
 
-from weechat import string_remove_color
-
 PowerLevel = namedtuple('PowerLevel', ['user', 'level'])
 
 
@@ -817,7 +815,7 @@ class RoomRedactionEvent(RoomEvent):
         new_message = ""
 
         if OPTIONS.redaction_type == RedactType.STRIKETHROUGH:
-            plaintext_msg = string_remove_color(message, '')
+            plaintext_msg = W.string_remove_color(message, '')
             new_message = string_strikethrough(plaintext_msg)
         elif OPTIONS.redaction_type == RedactType.NOTICE:
             new_message = message

--- a/tests/color_test.py
+++ b/tests/color_test.py
@@ -1,11 +1,14 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import unicode_literals
 
 import webcolors
+from collections import OrderedDict
 from hypothesis import given
 from hypothesis.strategies import sampled_from
 
-from matrix.colors import (Formatted, color_html_to_weechat,
-                           color_weechat_to_html)
+from matrix.colors import (Formatted, FormattedString,
+                           color_html_to_weechat, color_weechat_to_html)
 
 html_prism = ("<font color=maroon>T</font><font color=red>e</font><font "
               "color=olive>s</font><font color=yellow>t</font>")
@@ -27,3 +30,15 @@ def test_color_conversion(color_name):
     hex_color = color_weechat_to_html(color_html_to_weechat(color_name))
     new_color_name = webcolors.hex_to_name(hex_color, spec='html4')
     assert new_color_name == color_name
+
+
+def test_handle_strikethrough_first():
+    valid_result = '\x1b[038;5;1mf̶o̶o̶\x1b[039m'
+
+    d1 = OrderedDict([('fgcolor', 'red'), ('strikethrough', True)])
+    d2 = OrderedDict([('strikethrough', True), ('fgcolor', 'red'), ])
+    f1 = Formatted([FormattedString('foo', d1)])
+    f2 = Formatted([FormattedString('foo', d2)])
+
+    assert f1.to_weechat() == valid_result
+    assert f2.to_weechat() == valid_result


### PR DESCRIPTION
Strikethrough has to be done first, before handling any other attribute,
because otherwise it doesn't render correctly.

The following changes were made:

1. When striking due to redaction, we simply strip all the other
   attributes and then do the strikethrough, because this is the only
   practical option.
2. When rendering rich text received from the server, we ensure we
   handle strikethrough first, before any other attribute.