### PR TITLE
fix make install for mac os and add uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,21 @@ PYTHON ?= python
 lib := $(patsubst matrix/%.py, $(DESTDIR)$(PREFIX)/python/matrix/%.py, \
 	 $(wildcard matrix/*.py))
 
-install: install-lib
-	install -Dm644 main.py $(DESTDIR)$(PREFIX)/python/matrix.py
+install: install-dir install-lib
+	install -m644 main.py $(DESTDIR)$(PREFIX)/python/matrix.py
 
 install-lib: $(lib)
+install-dir:
+	install -d $(DESTDIR)$(PREFIX)/python/matrix
+
+uninstall:
+	rm $(DESTDIR)$(PREFIX)/python/matrix.py $(DESTDIR)$(PREFIX)/python/matrix/*
+	rmdir $(DESTDIR)$(PREFIX)/python/matrix
 
 phony:
 
 $(DESTDIR)$(PREFIX)/python/matrix/%.py: matrix/%.py phony
-	install -Dm644 $< $@
+	install -m644 $< $@
 
 test:
 	python3 -m pytest


### PR DESCRIPTION
On MacOS which is based on BSD the install command does not have the option -D for creating required directories.  It does however have the -d option to create directories.  This should make it easier for users who use weechat on a mac to install your plugin.