### PR TITLE
Fix parsing of unclosed Markdown delimiters.

### DIFF
--- a/matrix/colors.py
+++ b/matrix/colors.py
@@ -200,7 +200,7 @@ class Formatted(object):
                 text = text + line[i]
                 i = i + 1
 
-        substrings.append(FormattedString(text, attributes))
+        substrings.append(FormattedString(text, DEFAULT_ATTRIBUTES.copy()))
         return cls(substrings)
 
     @classmethod


### PR DESCRIPTION
Always append the last segment of the message with default attributes.
This prevents unclosed Markdown delimiters from starting Markdown
effects (for instance, `*foobar` won't display "foobar" as
emphasized/italicised).

Markdown parsing is still half-broken as it isn't a proper Markdown
parser, but this improves the situation somewhat.