### PR TITLE
Fix Configuration instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ Configuration is completed primarily through the Weechat interface.  First start
 
 1. Now set your username and password:
 
-       /set matrix.server.matrix.org.username johndoe
-       /set matrix.server.matrix.org.password jd_is_awesome
+       /set matrix.server.matrix_org.username johndoe
+       /set matrix.server.matrix_org.password jd_is_awesome
 
 1. Now try to connect:
 
-       /matrix connect matrix.org
+       /matrix connect matrix_org
 
 1. If everything works, save the configuration
 


### PR DESCRIPTION
The default matrix server is named matrix_org instead of matrix.org.

This is a great plugin all the matrix clients were far resource heavy for my liking and was already using weechat, Cheers :smile: 