### PR TITLE
Fix bar items contents for other buffers

### DIFF
--- a/matrix/bar_items.py
+++ b/matrix/bar_items.py
@@ -126,17 +126,19 @@ def matrix_bar_item_buffer_modes(data, item, window, buffer, extra_info):
 @utf8_decode
 def matrix_bar_nicklist_count(data, item, window, buffer, extra_info):
     # pylint: disable=unused-argument
+    color = W.color("status_nicklist_count")
+
     for server in SERVERS.values():
         if buffer in server.buffers.values():
             room_buffer = server.find_room_from_ptr(buffer)
             room = room_buffer.room
-            return str(room.member_count)
+            return "{}{}".format(color, room.member_count)
 
     nick_count = W.buffer_get_integer(buffer, "nicklist_nicks_count")
     nicklist_enabled = bool(W.buffer_get_integer(buffer, "nicklist"))
 
     if nicklist_enabled:
-        return str(nick_count)
+        return "{}{}".format(color, nick_count)
 
     return ""
 

--- a/matrix/bar_items.py
+++ b/matrix/bar_items.py
@@ -134,10 +134,10 @@ def matrix_bar_nicklist_count(data, item, window, buffer, extra_info):
             room = room_buffer.room
             return "{}{}".format(color, room.member_count)
 
-    nick_count = W.buffer_get_integer(buffer, "nicklist_nicks_count")
     nicklist_enabled = bool(W.buffer_get_integer(buffer, "nicklist"))
 
     if nicklist_enabled:
+        nick_count = W.buffer_get_integer(buffer, "nicklist_visible_count")
         return "{}{}".format(color, nick_count)
 
     return ""

--- a/matrix/bar_items.py
+++ b/matrix/bar_items.py
@@ -71,23 +71,7 @@ def matrix_bar_item_name(data, item, window, buffer, extra_info):
 
     name = W.buffer_get_string(buffer, "name")
 
-    if name:
-        localvar_type = W.buffer_get_string(buffer, "localvar_type")
-        is_channel = localvar_type == "channel"
-
-        if is_channel:
-            name = W.buffer_get_string(buffer, "localvar_channel")
-
-        return "{}{}{}{}{}{}".format(
-                W.color("bar_delim") if is_channel else "",
-                "(" if is_channel else "",
-                W.color("status_name"),
-                name,
-                W.color("bar_delim") if is_channel else "",
-                ")" if is_channel else "",
-        )
-
-    return ""
+    return "{}{}".format(W.color("status_name"), name)
 
 
 @utf8_decode


### PR DESCRIPTION
This fixes the values returned for the bar items for buffers not belonging to matrix so they are identical to the values used when matrix is not loaded.

This fixes the part of #54 about wrong values, but the issue that multiple scripts can't do this still remains. I've asked about it in #weechat on freenode, but not received any answer yet.