### PR TITLE
Improve Makefile adding auto-help when called with no args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,18 @@ PYTHON ?= python
 lib := $(patsubst matrix/%.py, $(DESTDIR)$(PREFIX)/python/matrix/%.py, \
 	 $(wildcard matrix/*.py))
 
-install: install-dir install-lib
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+install: install-dir install-lib ## Install the plugin to $(DESTDIR)/$(PREFIX)
 	install -m644 main.py $(DESTDIR)$(PREFIX)/python/matrix.py
 
 install-lib: $(lib)
 install-dir:
 	install -d $(DESTDIR)$(PREFIX)/python/matrix
 
-uninstall:
+uninstall: ## Uninstall the plugin from $(PREFIX)
 	rm $(DESTDIR)$(PREFIX)/python/matrix.py $(DESTDIR)$(PREFIX)/python/matrix/*
 	rmdir $(DESTDIR)$(PREFIX)/python/matrix
 
@@ -23,9 +27,9 @@ phony:
 $(DESTDIR)$(PREFIX)/python/matrix/%.py: matrix/%.py phony
 	install -m644 $< $@
 
-test:
+test: ## Run automated tests
 	python3 -m pytest
 	python2 -m pytest
 
-typecheck:
+typecheck: ## Run type check
 	mypy -p matrix --ignore-missing-imports --warn-redundant-casts


### PR DESCRIPTION
I wanted to also document a "build" (or "all") rule but the
existing one seems to be directly creating the files in the
install dir...