### PR TITLE
Remove list of dependencies from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,6 @@ support is still experimental.
     pip install -r requirements.txt
     ```
 
-    Another option is to install the dependencies manually:
-    - pyOpenSSL
-    - typing
-    - webcolors
-    - future (Python2 users only, see below)
-    - atomicwrites
-    - [matrix-nio](https://github.com/poljar/matrix-nio)
-    - attrs
-    - logbook
-    - pygments
-
 3. As your regular user, just run: `make install` in this repository directory.
 
     Note that weechat only supports Python2 OR Python3, and that setting is


### PR DESCRIPTION
The list of dependencies in the README was out of sync with the list in requirements.txt since weechat-matrix now requires e2ee support in matrix-nio. Opening requirements.txt and installing dependencies manually is either trivial to those who know python packaging or provides no benefit to those who do not. Removing this list reduces maintenance effort and does not make installation harder to understand.