### PR TITLE
Add options for controlling reconnect delay growth

### DIFF
--- a/matrix/_weechat.py
+++ b/matrix/_weechat.py
@@ -75,6 +75,8 @@ class MockConfig(object):
             'print_unconfirmed_messages': None,
             'read_markers_conditions': None,
             'typing_notice_conditions': None,
+            'autoreconnect_delay_growing': None,
+            'autoreconnect_delay_max': None,
         },
     }
 

--- a/matrix/config.py
+++ b/matrix/config.py
@@ -630,6 +630,26 @@ class MatrixConfig(WeechatConfig):
                  "value (in seconds)"),
             ),
             Option(
+                "autoreconnect_delay_growing",
+                "integer",
+                "",
+                1,
+                100,
+                "2",
+                ("growing factor for autoreconnect delay to server "
+                 "(1 = always same delay, 2 = delay*2 for each retry, etc.)"),
+            ),
+            Option(
+                "autoreconnect_delay_max",
+                "integer",
+                "",
+                0,
+                604800,
+                "600",
+                ("maximum autoreconnect delay to server "
+                 "(in seconds, 0 = no maximum)"),
+            ),
+            Option(
                 "print_unconfirmed_messages",
                 "boolean",
                 "",

--- a/matrix/server.py
+++ b/matrix/server.py
@@ -671,9 +671,16 @@ class MatrixServer(object):
         self.reconnect_time = time.time()
 
         if self.reconnect_delay:
-            self.reconnect_delay = self.reconnect_delay * 2
+            self.reconnect_delay = (
+                self.reconnect_delay
+                * G.CONFIG.network.autoreconnect_delay_growing
+            )
         else:
             self.reconnect_delay = self.config.reconnect_delay
+
+        if G.CONFIG.network.autoreconnect_delay_max > 0:
+            self.reconnect_delay = min(self.reconnect_delay,
+                G.CONFIG.network.autoreconnect_delay_max)
 
         message = (
             "{prefix}matrix: reconnecting to server in {t} " "seconds"


### PR DESCRIPTION
```
13:37 julius Hm, any way to limit the maximum reconnect delay?
16:56 &poljar the initial one? yes, as it grows, sadly not yet
18:33 <julius> as it grows. I amassed a 3 or so hour reconnect delay because I kept turning on my notebook only for a short time, and the first connect after resume-from-suspend always fails because wpa_supplicant is a slowpoke.
18:34 <&poljar> there's no way to limit it yet, but it would be fairly easy to add
18:51 <julius> I hope I have time this weekend…
…
14:56 <julius> Hm, if I add a maximum reconnect delay, should that be a server config property or just under network?
17:02 <&poljar> it's under network for the irc plugin, so i would say under network

```