### PR TITLE
Some Telegram bridges use "_telegram" prefix instead of plain "telegram"

### DIFF
--- a/matrix/buffer.py
+++ b/matrix/buffer.py
@@ -1057,6 +1057,7 @@ class RoomBuffer(object):
                 user.user_id.startswith("@whatsapp_") or
                 user.user_id.startswith("@facebook_") or
                 user.user_id.startswith("@telegram_") or
+                user.user_id.startswith("@_telegram_") or
                 user.user_id.startswith("@_xmpp_")):
             if user.display_name:
                 short_name = user.display_name[0:50]


### PR DESCRIPTION
Oh well, display names everywhere would be much nicer but meanwhile the if block needs some enlargement because some instances of Telegram bridges use `_telegram` prefix instead of `telegram`.