### PR TITLE
Download a screenful of history instead of fixed 10 messages

### DIFF
--- a/matrix/server.py
+++ b/matrix/server.py
@@ -943,10 +943,12 @@ class MatrixServer(object):
         if not room_buffer.prev_batch:
             return False
 
+        lines = W.window_get_integer(W.current_window(), "win_chat_height")
+
         uuid, request = self.client.room_messages(
             room_id,
             room_buffer.prev_batch,
-            limit=10)
+            limit=lines)
 
         room_buffer.backlog_pending = True
         self.backlog_queue[uuid] = room_id


### PR DESCRIPTION
When opening the chat window for the first time, load as many messages as there are chat window rows.

This is not perfect because messages may span multiple lines and in
some cases less messages are returned than "limit". But it's better
guess than magic number of 10, though.