### PR TITLE
Add new_channel_position config option

### DIFF
--- a/matrix/_weechat.py
+++ b/matrix/_weechat.py
@@ -61,6 +61,7 @@ class MockConfig(object):
             'pygments_style': None,
             'redactions': None,
             'server_buffer': None,
+            'new_channel_position': None,
         },
         'network': {
             'debug_buffer': None,
@@ -228,6 +229,14 @@ def buffer_get_string(_ptr, property):
     if property == "localvar_type":
         return "channel"
     return ""
+
+
+def buffer_get_integer(_ptr, property):
+    return 0
+
+
+def current_buffer():
+    return 1
 
 
 def nicklist_add_group(*_, **__):

--- a/matrix/buffer.py
+++ b/matrix/buffer.py
@@ -372,7 +372,7 @@ class WeechatChannelBuffer(object):
         if new_channel_position == NewChannelPosition.NONE:
             pass
         elif new_channel_position == NewChannelPosition.NEXT:
-            W.buffer_set(self._ptr, "number", str(cur_num + 1))
+            self.number = cur_num + 1
         elif new_channel_position == NewChannelPosition.NEAR_SERVER:
             server = G.SERVERS[server_name]
             last_similar_buffer_num = max(
@@ -380,7 +380,7 @@ class WeechatChannelBuffer(object):
                     in server.room_buffers.values()),
                 default=W.buffer_get_integer(server.server_buffer, "number")
             )
-            W.buffer_set(self._ptr, "number", str(last_similar_buffer_num + 1))
+            self.number = last_similar_buffer_num + 1
 
         self.name = ""
         self.users = {}  # type: Dict[str, WeechatUser]
@@ -868,6 +868,10 @@ class WeechatChannelBuffer(object):
     def number(self):
         """Get the buffer number, starts at 1."""
         return int(W.buffer_get_integer(self._ptr, "number"))
+
+    @number.setter
+    def number(self, n):
+        W.buffer_set(self._ptr, "number", str(n))
 
     def find_lines(self, predicate, max_lines=None):
         lines = []

--- a/matrix/buffer.py
+++ b/matrix/buffer.py
@@ -54,7 +54,7 @@ from nio import (
 
 from . import globals as G
 from .colors import Formatted
-from .config import RedactType
+from .config import RedactType, NewChannelPosition
 from .globals import SCRIPT_NAME, SERVERS, W, TYPING_NOTICE_TIMEOUT
 from .utf import utf8_decode
 from .message_renderer import Render
@@ -357,6 +357,9 @@ class WeechatChannelBuffer(object):
 
     def __init__(self, name, server_name, user):
         # type: (str, str, str) -> None
+
+        # Previous buffer num before create
+        cur_num = W.buffer_get_integer(W.current_buffer(), "number")
         self._ptr = W.buffer_new(
             name,
             "room_buffer_input_cb",
@@ -364,6 +367,14 @@ class WeechatChannelBuffer(object):
             "room_buffer_close_cb",
             server_name,
         )
+
+        new_channel_position = G.CONFIG.look.new_channel_position
+        if new_channel_position == NewChannelPosition.NONE:
+            pass
+        elif new_channel_position == NewChannelPosition.NEXT:
+            W.buffer_set(self._ptr, "number", str(cur_num + 1))
+        elif new_channel_position == NewChannelPosition.NEAR_SERVER:
+            pass
 
         self.name = ""
         self.users = {}  # type: Dict[str, WeechatUser]

--- a/matrix/buffer.py
+++ b/matrix/buffer.py
@@ -374,7 +374,13 @@ class WeechatChannelBuffer(object):
         elif new_channel_position == NewChannelPosition.NEXT:
             W.buffer_set(self._ptr, "number", str(cur_num + 1))
         elif new_channel_position == NewChannelPosition.NEAR_SERVER:
-            pass
+            server = G.SERVERS[server_name]
+            last_similar_buffer_num = max(
+                (room.weechat_buffer.number for room
+                    in server.room_buffers.values()),
+                default=W.buffer_get_integer(server.server_buffer, "number")
+            )
+            W.buffer_set(self._ptr, "number", str(last_similar_buffer_num + 1))
 
         self.name = ""
         self.users = {}  # type: Dict[str, WeechatUser]

--- a/matrix/config.py
+++ b/matrix/config.py
@@ -26,7 +26,7 @@ Server specific configuration options are handled in server.py
 
 from builtins import super
 from collections import namedtuple
-from enum import Enum, unique
+from enum import IntEnum, Enum, unique
 
 import logbook
 
@@ -49,6 +49,13 @@ class ServerBufferType(Enum):
     MERGE_CORE = 0
     MERGE = 1
     INDEPENDENT = 2
+
+
+@unique
+class NewChannelPosition(IntEnum):
+    NONE = 0
+    NEXT = 1
+    NEAR_SERVER = 2
 
 
 nio.logger_group.level = logbook.ERROR
@@ -425,6 +432,19 @@ class MatrixConfig(WeechatConfig):
                 "Merge server buffers",
                 ServerBufferType,
                 config_server_buffer_cb,
+            ),
+            Option(
+                "new_channel_position",
+                "integer",
+                "none|next|near_server",
+                min(NewChannelPosition),
+                max(NewChannelPosition),
+                "none",
+                "force position of new channel in list of buffers "
+                "(none = default position (should be last buffer), "
+                "next = current buffer + 1, near_server = after last "
+                "channel/pv of server)",
+                NewChannelPosition,
             ),
             Option(
                 "max_typing_notice_item_length",


### PR DESCRIPTION
Fixes #61

Wish list / things that [`irc-channel.c`](https://github.com/weechat/weechat/blob/a843e8fb1434385b923cbc9d09bbc50a98c98ca7/src/plugins/irc/irc-channel.c#L74-L122) doesn't do:
- [ ] Put all the private messages after the "channels"
- [ ] implement `new_pv_position` for private messages
- [ ] tests?