### PR TITLE
fix matrix_upload description

### DIFF
--- a/contrib/matrix_upload
+++ b/contrib/matrix_upload
@@ -251,7 +251,7 @@ def upload_process(args):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Download and decrypt matrix attachments"
+        description="Encrypt and upload matrix attachments"
     )
     parser.add_argument("file", help="the file that will be uploaded")
     parser.add_argument(


### PR DESCRIPTION
`matrix_upload` and `matrix_decrypt` incorrectly had the same description.