### PR TITLE
placeholder room name

### DIFF
--- a/matrix/buffer.py
+++ b/matrix/buffer.py
@@ -1164,6 +1164,10 @@ class RoomBuffer(object):
         else:
             room_name = self.room.display_name
 
+        if room_name is None:
+            # Use placeholder room name
+            room_name = '...'
+
         self.weechat_buffer.short_name = room_name
 
         if G.CONFIG.human_buffer_names:

--- a/matrix/buffer.py
+++ b/matrix/buffer.py
@@ -1166,7 +1166,7 @@ class RoomBuffer(object):
 
         if room_name is None:
             # Use placeholder room name
-            room_name = '...'
+            room_name = 'Empty room (?)'
 
         self.weechat_buffer.short_name = room_name
 


### PR DESCRIPTION
My room list loads nicely when I connect to Matrix for the first time. But when I connect for the second time, I get the following error and the room list does not load:
![Screenshot_2020-01-21_21-10-39](https://user-images.githubusercontent.com/33424247/72839794-38dba800-3c93-11ea-806d-dcd6557afa97.png)
I found out it happened because buffer names were being set to `None`. I was able to fix this by adding a placeholder name. Now rooms get the name `"..."`, and a few seconds later, as more events are received from the server, they change to their actual names.