### PR TITLE
matrix-nio == 0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ atomicwrites
 attrs
 logbook
 pygments
-matrix-nio[e2e]>=0.6
+matrix-nio[e2e]==0.6
 aiohttp ; python_version >= "3.5"
 python-magic
 requests


### PR DESCRIPTION
If nio 0.9 is installed, the build fails for python 2.7. Unfortunately you're not able to change the used python version in weechat. This change should stay until all stable systems are using python3 as default.

Worked for me with `pip install matrix-nio[e2e]==0.6`.