### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,15 @@ attrs = "^19.3.0"
 logbook = "^1.5.3"
 pygments = "^2.6.1"
 matrix-nio = { version = "^0.9.0", extras = [ "e2e" ] }
-python-magic = "^0.4.15"
-aiohttp = "^3.6.2"
-requests = "^2.23.0"
+python-magic = { version = "^0.4.15", optional = true }
+aiohttp = { version = "^3.6.2", optional = true }
+requests = { version = "^2.23.0", optional = true }
 typing = { version = "^3.7.4", python = "<3.5" }
+
+[tool.poetry.extras]
+matrix_decrypt = ["requests"]
+matrix_sso_helper = ["aiohttp"]
+matrix_upload = ["python-magic", "requests"]
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ matrix-nio = { version = "^0.9.0", extras = [ "e2e" ] }
 python-magic = "^0.4.15"
 aiohttp = "^3.6.2"
 requests = "^2.23.0"
-typing = "^3.7.4; python_version < 3.5"
+typing = { version = "^3.7.4", python = "<3.5" }
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
The current `pyproject.toml`  contains an invalid version specification for `typing`. Also make the dependencies on `python-magic`, `aiohttp` and `requests`  since they are only used in the contrib scripts.