### PR TITLE
commands: prevent python crash when typing simply "/olm"

### DIFF
--- a/matrix/commands.py
+++ b/matrix/commands.py
@@ -591,7 +591,7 @@ def olm_info_command(server, args):
 
     olm = server.client.olm
 
-    if args.category == "private":
+    if not hasattr(args, 'category') or args.category == "private":
         fp_key = partition_key(olm.account.identity_keys["ed25519"])
         message = ("Identity keys:\n"
                    "  - User:        {user_color}{user}{ncolor}\n"


### PR DESCRIPTION
Typing `/olm` on its own is supposed to fall back to the default subcommand `/olm info private`. It does pick up `info`, but fails to find a `category` (in our case: we want `private`) because the category has never been parsed, and has never been assigned to `args`. Not only does the command fail, but it even yields a traceback:

    python : stdout/stderr (matrix) : Traceback (most recent call last):
    python : stdout/stderr (matrix) :   File "/home/qmo/weechat/conf/python/matrix/utf.py", line 89, in wrapper
    python : stdout/stderr (matrix) :     return function(*args, **kwargs)
    python : stdout/stderr (matrix) :   File "/home/qmo/weechat/conf/python/matrix/commands.py", line 891, in matrix_olm_command_cb
    python : stdout/stderr (matrix) :     return command(server, data, buffer, args)
    python : stdout/stderr (matrix) :   File "/home/qmo/weechat/conf/python/matrix/commands.py", line 860, in command
    python : stdout/stderr (matrix) :     olm_info_command(server, parsed_args)
    python : stdout/stderr (matrix) :   File "/home/qmo/weechat/conf/python/matrix/commands.py", line 594, in olm_info_command
    python : stdout/stderr (matrix) :     if args.category == "private":
    python : stdout/stderr (matrix) : AttributeError: 'Namespace' object has no attribute 'category'

Fix it by going for `private` if no category has been assigned.