### PR TITLE
commands: fix user/device ids in error messages for "/olm verification"

### DIFF
--- a/matrix/commands.py
+++ b/matrix/commands.py
@@ -807,15 +807,15 @@ def olm_sas_command(server, args):
         device = device_store[args.user_id][args.device_id]
     except KeyError:
         server.error("Device {} of user {} not found".format(
-            args.user_id,
-            args.device_id
+            args.device_id,
+            args.user_id
         ))
         return W.WEECHAT_RC_OK
 
     if device.deleted:
         server.error("Device {} of user {} is deleted.".format(
-            args.user_id,
-            args.device_id
+            args.device_id,
+            args.user_id
         ))
         return W.WEECHAT_RC_OK
 


### PR DESCRIPTION
When passing arguments to format error messages for `/olm verification`, the order of device id and user id has been swapped, leading to confusing messages. Let's restore the correct order.