### PR TITLE
Add quote_wrap option

### DIFF
--- a/matrix/colors.py
+++ b/matrix/colors.py
@@ -356,11 +356,15 @@ class Formatted(object):
                 quote_pair = color_pair(G.CONFIG.color.quote_fg,
                                         G.CONFIG.color.quote_bg)
 
+                # Remove leading and trailing newlines; Riot sends an extra
+                # quoted "\n" when a user quotes a message.
+                string = string.strip("\n")
+                if len(string) == 0:
+                    return string
+
                 if G.CONFIG.look.quote_wrap >= 0:
                     wrapper = self.textwrapper(G.CONFIG.look.quote_wrap, quote_pair)
-                    return wrapper.fill(
-                        W.string_remove_color(string.replace("\n", ""), "")
-                    )
+                    return wrapper.fill(W.string_remove_color(string, ""))
                 else:
                     # Don't wrap, just add quote markers to all lines
                     return "{color_on}{text}{color_off}".format(

--- a/matrix/colors.py
+++ b/matrix/colors.py
@@ -62,14 +62,11 @@ class Formatted(object):
         # type: (List[FormattedString]) -> None
         self.substrings = substrings
 
-    @property
-    def textwrapper(self):
-        quote_pair = color_pair(G.CONFIG.color.quote_fg,
-                                G.CONFIG.color.quote_bg)
+    def textwrapper(self, width, colors):
         return textwrap.TextWrapper(
-            width=67,
-            initial_indent="{}> ".format(W.color(quote_pair)),
-            subsequent_indent="{}> ".format(W.color(quote_pair)),
+            width=width,
+            initial_indent="{}> ".format(W.color(colors)),
+            subsequent_indent="{}> ".format(W.color(colors)),
         )
 
     def is_formatted(self):
@@ -356,9 +353,21 @@ class Formatted(object):
             elif name == "strikethrough":
                 return string_strikethrough(string)
             elif name == "quote":
-                return self.textwrapper.fill(
-                    W.string_remove_color(string.replace("\n", ""), "")
-                )
+                quote_pair = color_pair(G.CONFIG.color.quote_fg,
+                                        G.CONFIG.color.quote_bg)
+
+                if G.CONFIG.look.quote_wrap >= 0:
+                    wrapper = self.textwrapper(G.CONFIG.look.quote_wrap, quote_pair)
+                    return wrapper.fill(
+                        W.string_remove_color(string.replace("\n", ""), "")
+                    )
+                else:
+                    # Don't wrap, just add quote markers to all lines
+                    return "{color_on}{text}{color_off}".format(
+                        color_on=W.color(quote_pair),
+                        text="> " + W.string_remove_color(string.replace("\n", "\n> "), ""),
+                        color_off=W.color("resetcolor")
+                    )
             elif name == "code":
                 code_color_pair = color_pair(
                     G.CONFIG.color.untagged_code_fg,

--- a/matrix/config.py
+++ b/matrix/config.py
@@ -541,6 +541,16 @@ class MatrixConfig(WeechatConfig):
                  "block"),
             ),
             Option(
+                "quote_wrap",
+                "integer",
+                "",
+                -1,
+                1000,
+                "67",
+                ("After how many characters to soft-wrap lines in a quote "
+                 "block (reply message). Set to -1 to disable soft-wrapping."),
+            ),
+            Option(
                 "human_buffer_names",
                 "boolean",
                 "",


### PR DESCRIPTION
This adds a config option to change (or disable) the automatic soft-wrapping width of blockquotes.

Rationale: my terminal is fairly wide, and the default of 67 chars looks fairly stupid in it.

Note that the default of 67 chars is unchanged by this PR: if the user doesn't change the config option, there should be no visible change in behaviour.

I'm not sure about the `textwrapper()` method on the `Formatted` class; it didn't use `self` before, and still doesn't, and was only used in one place. Anyway, I left it mostly the same as it was, though I made it a proper method instead of a `@property` because I wanted to pass some arguments.