### PR TITLE
Don't parse backslashes in code blocks

### DIFF
--- a/matrix/colors.py
+++ b/matrix/colors.py
@@ -92,7 +92,7 @@ class Formatted(object):
         # when (quickly) looking for the last delimiters in the line. Note that
         # the replacement needs to be the same length as the original for the
         # indices to be correct.
-        escaped_masked = re.sub(r"\\[\*_`]", "aa", line)
+        escaped_masked = re.sub(r"\\[\\*_`]", "aa", line)
 
         def last_match_index(regex, offset_in_match):
             matches = list(re.finditer(regex, escaped_masked))
@@ -136,13 +136,17 @@ class Formatted(object):
             "\x1F": "underline",
         }
 
+        # Characters that consume a prefixed backslash
+        escapable_chars = wrapper_init_chars.copy()
+        escapable_chars.add("\\")
+
         i = 0
         while i < len(line):
             # Markdown escape
-            # NOTE: IRC-native formatting characters are not escaped
             if i + 1 < len(line) and line[i] == "\\" \
-                    and line[i + 1] not in "\x02\x03\x0F\x1D\x1F" \
-                    and (not attributes["code"] or line[i + 1] == "`"):
+                    and (line[i + 1] in escapable_chars
+                            if not attributes["code"]
+                            else line[i + 1] == "`"):
                 text += line[i + 1]
                 i = i + 2
 

--- a/matrix/colors.py
+++ b/matrix/colors.py
@@ -122,7 +122,8 @@ class Formatted(object):
             # Markdown escape
             # NOTE: IRC-native formatting characters are not escaped
             if i + 1 < len(line) and line[i] == "\\" \
-                    and line[i + 1] not in "\x02\x03\x0F\x1D\x1F":
+                    and line[i + 1] not in "\x02\x03\x0F\x1D\x1F" \
+                    and (not attributes["code"] or line[i + 1] == "`"):
                 text += line[i + 1]
                 i = i + 2
 

--- a/tests/color_test.py
+++ b/tests/color_test.py
@@ -109,6 +109,16 @@ def test_input_line_markdown_various2():
     assert "norm** <code>code **code *code</code> norm `norm" \
            == formatted.to_html()
 
+def test_input_line_backslash():
+    def convert(s): return Formatted.from_input_line(s).to_html()
+    assert "pre <em>italic* ital</em> norm" == convert("pre *italic\\* ital* norm")
+    assert "*norm* norm" == convert("\\*norm* norm")
+    assert "<em>*ital</em>" == convert("*\\*ital*")
+    assert "<code>C:\\path</code>" == convert("`C:\\path`")
+    assert "<code>with`tick</code>" == convert("`with\\`tick`")
+    assert "`un`matched" == convert("`un\\`matched")
+    assert "<strong>bold </strong><em><strong>*bital</strong></em> norm" == convert("**bold *\\*bital*** norm")
+
 def test_conversion():
     formatted = Formatted.from_input_line("*Hello*")
     formatted2 = Formatted.from_html(formatted.to_html())


### PR DESCRIPTION
This fixes a bug in my earlier PR #202: backslashes were not properly kept in code blocks. After this fix, they are.

Edit after second commit: markdown parsing is less trivial than I thought, thanks to dkasak for suggesting this needed more tests... :)