### PR TITLE
Allow quotes in replied-to messages

### DIFF
--- a/matrix/commands.py
+++ b/matrix/commands.py
@@ -1360,7 +1360,7 @@ def matrix_reply_command_cb(data, buffer, args):
             # necessary purpose
             event_id, reply = parse_redact_args(args)
 
-            if not event_id:
+            if not event_id or not reply:
                 message = (
                     "{prefix}matrix: Invalid command "
                     "arguments (see /help reply)"

--- a/matrix/completion.py
+++ b/matrix/completion.py
@@ -137,13 +137,16 @@ def matrix_message_completion_cb(data, completion_item, buffer, completion):
                 if not event_id:
                     continue
 
-                message = line.message
+                # Make sure we'll be able to reliably detect the end of the
+                # quoted snippet
+                message_fmt = line.message.replace("\\", "\\\\") \
+                                          .replace('"', '\\"')
 
-                if len(message) > REDACTION_COMP_LEN + 2:
-                    message = message[:REDACTION_COMP_LEN] + ".."
+                if len(message_fmt) > REDACTION_COMP_LEN + 2:
+                    message_fmt = message_fmt[:REDACTION_COMP_LEN] + ".."
 
                 item = ('{event_id}|"{message}"').format(
-                    event_id=event_id, message=message
+                    event_id=event_id, message=message_fmt
                 )
 
                 W.hook_completion_list_add(

--- a/matrix/utils.py
+++ b/matrix/utils.py
@@ -182,10 +182,18 @@ def parse_redact_args(args):
             event_id, rest = (args, "")
 
     if had_example_text:
-        try:
-            _, _, reason = rest.split("\"", 2)
-        except ValueError:
-            reason = None
+        rest = rest.lstrip()
+        reason = None  # until it has been correctly determined
+        if rest[0] == '"':
+            escaped = False
+            for i in range(1, len(rest)):
+                if escaped:
+                    escaped = False
+                elif rest[i] == "\\":
+                    escaped = True
+                elif rest[i] == '"':
+                    reason = rest[i+1:]
+                    break
     else:
         reason = rest
 


### PR DESCRIPTION
If a message replied to had a `"` in the first part that is quoted when using `/redact` or `/reply-matrix`, the parsing mechanism in `parse_redact_args` got confused and thought the snippet ended at the first `"`, which was actually part of the message quoted.

This adds some backslashes so that this confusion does not happen anymore.