### PR TITLE
Escape manually entered html characters

### DIFF
--- a/matrix/colors.py
+++ b/matrix/colors.py
@@ -335,6 +335,11 @@ class Formatted(object):
             text = formatted_string.text
             attributes = formatted_string.attributes.copy()
 
+            # Escape HTML tag characters
+            text = text.replace("&", "&amp;") \
+                       .replace("<", "&lt;") \
+                       .replace(">", "&gt;")
+
             if attributes["code"]:
                 if attributes["preformatted"]:
                     # XXX: This can't really happen since there's no way of


### PR DESCRIPTION
Previously, the behaviour was inconsistent; if there was no other formatting, weechat-matrix doesn't send `formatted_body`, and Riot would display the message as-is. If there _was_ other formatting, `formatted_body` is sent without escaping of the HTML characters, so that Riot would interpret them as HTML.

This makes both cases consistent, using the first behaviour.