### PR TITLE
Namespace buffers with "matrix."

### DIFF
--- a/matrix/buffer.py
+++ b/matrix/buffer.py
@@ -904,7 +904,7 @@ class RoomBuffer(object):
 
         self.last_message = None
 
-        buffer_name = "matrix.{}.{}".format(server_name, room.room_id)
+        buffer_name = "{}.{}.{}".format(G.SCRIPT_NAME, server_name, room.room_id)
 
         # This dict remembers the connection from a user_id to the name we
         # displayed in the buffer

--- a/matrix/buffer.py
+++ b/matrix/buffer.py
@@ -904,7 +904,7 @@ class RoomBuffer(object):
 
         self.last_message = None
 
-        buffer_name = "{}.{}".format(server_name, room.room_id)
+        buffer_name = "matrix.{}.{}".format(server_name, room.room_id)
 
         # This dict remembers the connection from a user_id to the name we
         # displayed in the buffer


### PR DESCRIPTION
This allows setting key bindings specifically for matrix buffers. As discussed on #weechat-matrix.

It doesn't seem to break anything for me.