### PR TITLE
Reply using 'r' in cursor mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,27 @@ settings:
 1. `matrix.network.read_markers_conditions`
 1. `matrix.network.typing_notice_conditions`
 
+## Cursor bindings
+
+While you can reply on a matrix message using the `/reply-matrix` command (see
+its help in weechat), weechat-matrix also adds a binding in `/cursor` mode to
+easily reply to a particular message. This mode can be triggered either by
+running `/cursor`, or by middle-clicking somewhere on the screen. See weechat's
+help for `/cursor`.
+
+The default binding is:
+
+    /key bindctxt cursor @chat(python.matrix.*):r hsignal:matrix_cursor_reply
+
+This means that you can reply to a message in a Matrix buffer using the middle
+mouse button, then `r`.
+
+This binding is automatically set when the script is loaded and there is no
+such binding yet. If you want to use a different key than `r`, you can execute
+the above command with a different key in place of `r`. To use modifier keys
+like control and alt, use alt-k, then your wanted binding key combo, to enter
+weechat's representation of that key combo in the input bar.
+
 ## Navigating room buffers using go.py
 
 If you try to use the `go.py` script to navigate buffers created by

--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ from matrix.bar_items import (
 from matrix.buffer import room_buffer_close_cb, room_buffer_input_cb
 # Weechat searches for the registered callbacks in the scope of the main script
 # file, import the callbacks here so weechat can find them.
-from matrix.commands import (hook_commands, hook_page_up,
+from matrix.commands import (hook_commands, hook_key_bindings, hook_page_up,
                              matrix_command_buf_clear_cb, matrix_command_cb,
                              matrix_command_pgup_cb, matrix_invite_command_cb,
                              matrix_join_command_cb, matrix_kick_command_cb,
@@ -74,7 +74,8 @@ from matrix.commands import (hook_commands, hook_page_up,
                              matrix_olm_command_cb, matrix_devices_command_cb,
                              matrix_room_command_cb, matrix_uploads_command_cb,
                              matrix_upload_command_cb, matrix_send_anyways_cb,
-                             matrix_reply_command_cb)
+                             matrix_reply_command_cb,
+                             matrix_cursor_reply_signal_cb)
 from matrix.completion import (init_completion, matrix_command_completion_cb,
                                matrix_debug_completion_cb,
                                matrix_message_completion_cb,
@@ -695,6 +696,7 @@ if __name__ == "__main__":
         G.CONFIG.read()
 
         hook_commands()
+        hook_key_bindings()
         init_bar_items()
         init_completion()
 

--- a/matrix/buffer.py
+++ b/matrix/buffer.py
@@ -904,7 +904,7 @@ class RoomBuffer(object):
 
         self.last_message = None
 
-        buffer_name = "{}.{}.{}".format(G.SCRIPT_NAME, server_name, room.room_id)
+        buffer_name = "{}{}.{}".format(G.BUFFER_NAME_PREFIX, server_name, room.room_id)
 
         # This dict remembers the connection from a user_id to the name we
         # displayed in the buffer

--- a/matrix/globals.py
+++ b/matrix/globals.py
@@ -42,6 +42,7 @@ SERVERS = dict()  # type: Dict[str, MatrixServer]
 CONFIG = None  # type: Any
 ENCRYPTION = True  # type: bool
 SCRIPT_NAME = "matrix"  # type: str
+BUFFER_NAME_PREFIX = "{}.".format(SCRIPT_NAME)  # type: str
 TYPING_NOTICE_TIMEOUT = 4000  # 4 seconds typing notice lifetime
 LOGGER = Logger("weechat-matrix")
 UPLOADS = OrderedDict()  # type: Dict[str, Upload]


### PR DESCRIPTION
This allows using middleclick-R to reply to a particular message.

The key is never unbound by the script. This is also [wee-slack](https://github.com/wee-slack/wee-slack/#cursor-and-mouse-mode)'s behaviour. It was discussed in #weechat-matrix that we can possibly copy this.