### PR TITLE
Tinker with makefile to avoid directory-file race conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,12 @@ lib := $(patsubst matrix/%.py, $(DESTDIR)$(PREFIX)/python/matrix/%.py, \
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-install: install-dir install-lib ## Install the plugin to $(DESTDIR)/$(PREFIX)
+install: install-lib | $(DESTDIR)$(PREFIX)/python/matrix/ ## Install the plugin to $(DESTDIR)/$(PREFIX)
 	install -m644 main.py $(DESTDIR)$(PREFIX)/python/matrix.py
 
 install-lib: $(lib)
-install-dir:
-	install -d $(DESTDIR)$(PREFIX)/python/matrix
+$(DESTDIR)$(PREFIX)/python/matrix/:
+	install -d $@
 
 uninstall: ## Uninstall the plugin from $(PREFIX)
 	rm $(DESTDIR)$(PREFIX)/python/matrix.py $(DESTDIR)$(PREFIX)/python/matrix/*
@@ -24,7 +24,7 @@ uninstall: ## Uninstall the plugin from $(PREFIX)
 
 phony:
 
-$(DESTDIR)$(PREFIX)/python/matrix/%.py: matrix/%.py phony
+$(DESTDIR)$(PREFIX)/python/matrix/%.py: matrix/%.py phony | $(DESTDIR)$(PREFIX)/python/matrix/
 	install -m644 $< $@
 
 test: ## Run automated tests

--- a/Makefile
+++ b/Makefile
@@ -4,27 +4,29 @@ WEECHAT_HOME ?= $(HOME)/.weechat
 PREFIX ?= $(WEECHAT_HOME)
 PYTHON ?= python
 
-lib := $(patsubst matrix/%.py, $(DESTDIR)$(PREFIX)/python/matrix/%.py, \
+INSTALLDIR := $(DESTDIR)$(PREFIX)/python/matrix
+
+lib := $(patsubst matrix/%.py, $(INSTALLDIR)/%.py, \
 	 $(wildcard matrix/*.py))
 
 .PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-install: install-lib | $(DESTDIR)$(PREFIX)/python/matrix/ ## Install the plugin to $(DESTDIR)/$(PREFIX)
+install: install-lib | $(INSTALLDIR) ## Install the plugin to $(DESTDIR)/$(PREFIX)
 	install -m644 main.py $(DESTDIR)$(PREFIX)/python/matrix.py
 
 install-lib: $(lib)
-$(DESTDIR)$(PREFIX)/python/matrix/:
+$(INSTALLDIR):
 	install -d $@
 
 uninstall: ## Uninstall the plugin from $(PREFIX)
-	rm $(DESTDIR)$(PREFIX)/python/matrix.py $(DESTDIR)$(PREFIX)/python/matrix/*
-	rmdir $(DESTDIR)$(PREFIX)/python/matrix
+	rm $(DESTDIR)$(PREFIX)/python/matrix.py $(INSTALLDIR)/*
+	rmdir $(INSTALLDIR)
 
 phony:
 
-$(DESTDIR)$(PREFIX)/python/matrix/%.py: matrix/%.py phony | $(DESTDIR)$(PREFIX)/python/matrix/
+$(INSTALLDIR)/%.py: matrix/%.py phony | $(INSTALLDIR)
 	install -m644 $< $@
 
 test: ## Run automated tests


### PR DESCRIPTION
This fixes #222 

Uses [order-only prerequisites](https://www.gnu.org/software/make/manual/make.html#Prerequisite-Types) in the makefile to signal that the directory needs to be created only once before anything that depends on the directory existing.