### PR TITLE
Toggle markdown parsing with matrix.look.markdown_input

### DIFF
--- a/matrix/_weechat.py
+++ b/matrix/_weechat.py
@@ -62,6 +62,7 @@ class MockConfig(object):
             'redactions': None,
             'server_buffer': None,
             'new_channel_position': None,
+            'markdown_input': True,
         },
         'network': {
             'debug_buffer': None,

--- a/matrix/colors.py
+++ b/matrix/colors.py
@@ -88,6 +88,9 @@ class Formatted(object):
         substrings = []  # type: List[FormattedString]
         attributes = DEFAULT_ATTRIBUTES.copy()
 
+        # If this is false, only IRC formatting characters will be parsed.
+        do_markdown = G.CONFIG.look.markdown_input
+
         # Disallow backticks in URLs so that code blocks are unaffected by the
         # URL handling
         url_regex = r"\b[a-z]+://[^\s`]+"
@@ -169,7 +172,8 @@ class Formatted(object):
                 in_url = True
 
             # Markdown escape
-            if i + 1 < len(line) and line[i] == "\\" \
+            if do_markdown and \
+                    i + 1 < len(line) and line[i] == "\\" \
                     and (line[i + 1] in escapable_chars
                             if not attributes["code"]
                             else line[i + 1] == "`") \
@@ -235,7 +239,7 @@ class Formatted(object):
                     attributes["bgcolor"] = None
 
             # Markdown wrapper (emphasis/bold/code)
-            elif line[i] in wrapper_init_chars and not in_url:
+            elif do_markdown and line[i] in wrapper_init_chars and not in_url:
                 for l in range(wrapper_max_len, 0, -1):
                     if i + l <= len(line) and line[i : i + l] in wrappers:
                         descriptor = wrappers[line[i : i + l]]

--- a/matrix/config.py
+++ b/matrix/config.py
@@ -597,6 +597,16 @@ class MatrixConfig(WeechatConfig):
                  "since conflicts can happen otherwise "
                  "(requires a script reload)."),
             ),
+            Option(
+                "markdown_input",
+                "boolean",
+                "",
+                0,
+                0,
+                "on",
+                ("If turned on, markdown usage in messages will be converted "
+                 "to actual markup (**bold**, *italic*, _italic_, `code`)."),
+            ),
         ]
 
         network_options = [

--- a/tests/color_test.py
+++ b/tests/color_test.py
@@ -60,7 +60,7 @@ def test_normalize_spaces_in_inline_code():
 
 @given(
     text(alphabet=characters(min_codepoint=32,
-                             blacklist_characters="*_"))
+                             blacklist_characters="*_`"))
     .map(lambda s: '*' + s))
 def test_unpaired_prefix_asterisk_without_space_is_literal(text):
    """An unpaired asterisk at the beginning of the line, without a space


### PR DESCRIPTION
As requested in #weechat-matrix around 2020-08-25 20:30 UTC, this adds a config option that toggles whether or not markdown is parsed in chat message input. The config option is set to true by default, because:
1. this is currently the expected behaviour; setting it to off by default would be a breaking change
2. if people didn't like it, more would have complained before now; as it is, I know of only one person.

If the option is set to false, some of the preprocessing code and url-protecting code still runs, even though it doesn't end up doing anything useful. If this is considered a performance issue, I do not see a better option than creating a partial copy of the `from_input_line` function that only does IRC format char parsing; I did not do this yet in the interest of DRY.