### PR TITLE
Fix leading whitespace in "/python version" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ accepted and welcome.
 
     To check the python version that weechat is using, run:
 
-        /python version
+       /python version
 
 ## Using virtualenv
 If you want to install dependencies inside a virtualenv, rather than


### PR DESCRIPTION
If you just copy and paste the current "/python version" command from the docs, you will have a leading whitespace character which Weechat will not like.