### PR TITLE
Tweaks to contrib/matrix_decrypt.py

### DIFF
--- a/contrib/matrix_decrypt.py
+++ b/contrib/matrix_decrypt.py
@@ -75,7 +75,7 @@ def main():
     if args.file is None:
         file_name = save_file(plaintext)
         if plumber is None:
-            plumber = "/usr/bin/rifle"
+            plumber = "xdg-open"
     else:
         file_name = args.file
         open(file_name, "wb").write(plaintext)

--- a/contrib/matrix_decrypt.py
+++ b/contrib/matrix_decrypt.py
@@ -81,7 +81,7 @@ def main():
         open(file_name, "wb").write(plaintext)
 
     if plumber is not None:
-        subprocess.run([plumber, "{file}".format(file=file_name)])
+        subprocess.run([plumber, file_name])
 
     return 0
 

--- a/contrib/matrix_decrypt.py
+++ b/contrib/matrix_decrypt.py
@@ -44,6 +44,7 @@ def main():
         description='Download and decrypt matrix attachments'
     )
     parser.add_argument('url', help='the url of the attachment')
+    parser.add_argument('file', nargs='?', help='save attachment to <file>')
     parser.add_argument('--plumber',
                         help='program that gets called with the '
                              'dowloaded file')
@@ -68,11 +69,19 @@ def main():
         print("Error downloading file")
         return -2
 
-    plumber = args.plumber or "/usr/bin/rifle"
+    plumber = args.plumber
     plaintext = decrypt_attachment(request.content, key, hash, iv)
-    file_name = save_file(plaintext)
 
-    subprocess.run([plumber, "{file}".format(file=file_name)])
+    if args.file is None:
+        file_name = save_file(plaintext)
+        if plumber is None:
+            plumber = "/usr/bin/rifle"
+    else:
+        file_name = args.file
+        open(file_name, "wb").write(plaintext)
+
+    if plumber is not None:
+        subprocess.run([plumber, "{file}".format(file=file_name)])
 
     return 0
 


### PR DESCRIPTION
I recently tried to use `matrix_decrypt.py`, but found its usage a bit odd. I generally wanted to save attachments to a known path, not to "run" them with something.

As such I added a second (optional) positional argument to specify a destination file. If a path has been specified, we just save without running the default plumber.

Running with a single argument runs the plumber as before, and specifying a custom plumber allows to both save and run the plumber.

In the second commit I change the default plumber from "rifle" to "xdg-open". Despite loving ranger, IMHO xdg-open is something which is a bit more useful for the general public.