### PR TITLE
Set backlog_pending to false on error

### DIFF
--- a/matrix/server.py
+++ b/matrix/server.py
@@ -60,6 +60,7 @@ from nio import (
     DeleteDevicesResponse,
     TransportType,
     RoomMessagesResponse,
+    RoomMessagesError,
     EncryptionError,
     GroupEncryptionError,
     OlmTrustError,
@@ -1618,8 +1619,9 @@ class MatrixServer(object):
 
         if isinstance(response, ErrorResponse):
             self.handle_error_response(response)
-            room_buffer = self.room_buffers[response.room_id]
-            room_buffer.backlog_pending = False
+            if isinstance(response, RoomMessagesError):
+                room_buffer = self.room_buffers[response.room_id]
+                room_buffer.backlog_pending = False
 
         elif isinstance(response, ToDeviceResponse):
             try:

--- a/matrix/server.py
+++ b/matrix/server.py
@@ -1618,6 +1618,8 @@ class MatrixServer(object):
 
         if isinstance(response, ErrorResponse):
             self.handle_error_response(response)
+            room_buffer = self.room_buffers[response.room_id]
+            room_buffer.backlog_pending = False
 
         elif isinstance(response, ToDeviceResponse):
             try:


### PR DESCRIPTION
Previously, once there's one response error, it's impossible to fetch any more backlog.

That bug might be the cause of #213 .

------

I'm not sure what's the best place to put it; or if there's any type of error (handled by that code) not caused by fetching backlog. The callbacks make it *really* hard to see what the program will execute next.