### PR TITLE
Use the configured encryption warning sign in the buffer prefix

### DIFF
--- a/matrix/buffer.py
+++ b/matrix/buffer.py
@@ -942,7 +942,7 @@ class RoomBuffer(object):
 
     @property
     def warning_prefix(self):
-        return "⚠️ "
+        return G.CONFIG.encryption_warning_sign
 
     @property
     def typing(self):


### PR DESCRIPTION
The configured warning sign previously only applied to the bar.