### PR TITLE
Only require 'future' for python <3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pyOpenSSL
 typing ; python_version < "3.5"
 webcolors
-future
+future; python_version < "3.2"
 atomicwrites
 attrs
 logbook


### PR DESCRIPTION
From #python on Freenode IRC network:
> 09:04:44 graingert | strk: you should probably remove that requirement, it's outdated
> 09:05:24 graingert | Or change it to `future; python_version < '3.2'`
