### PR TITLE
colors: Do not use [] indexing on re.match objects

### DIFF
--- a/matrix/colors.py
+++ b/matrix/colors.py
@@ -103,7 +103,7 @@ class Formatted(object):
         # for the indices to be correct.
         escaped_masked = re.sub(
             r"\\[\\*_`]|(?:" + url_regex + ")",
-            lambda m: "a" * len(m[0]),
+            lambda m: "a" * len(m.group(0)),
             line
         )
 


### PR DESCRIPTION
This indexing (i.e. `__getitem__`) introduced in Python 3.5 as an alias of
the group method, so using it breaks this plugin on older Python
versions. In particular, messages containing urls cannot be sent and
result in an exception:

	File "matrix/colors.py", line 106, in <lambda>
	    lambda m: "a" * len(m[0]),
	TypeError: '_sre.SRE_Match' object has no attribute '__getitem__'

This commit replaces the use of the index operation / `__getitem__` with
the group method, which is equivalent but supported on all python
versions.