### PR TITLE
Support Heisenbridge short names

### DIFF
--- a/matrix/buffer.py
+++ b/matrix/buffer.py
@@ -1072,7 +1072,8 @@ class RoomBuffer(object):
                 user.user_id.startswith("@facebook_") or
                 user.user_id.startswith("@telegram_") or
                 user.user_id.startswith("@_telegram_") or
-                user.user_id.startswith("@_xmpp_")):
+                user.user_id.startswith("@_xmpp_") or
+                user.user_id.startswith("@irc_")):
             if user.display_name:
                 short_name = user.display_name[0:50]
         elif user.user_id.startswith("@twilio_"):


### PR DESCRIPTION
Adds support for [Heisenbridge](https://github.com/hifi/heisenbridge) IRC bridge short names for any network.

I know it's a niche bridge but I'm also slightly annoyed I need to manually patch this in all the time :sweat_smile: 

The full ID format is `@irc_network_nick` and for increased accuracy we could test it against a regex to prevent accidental naming issues but I'm not sure if it's worth the effort.

In the Rust version it would probably be more correct to have configuration settings so you can set this per homeserver where you know what prefix is reserved for which bridge and have defaults in that match what matrix.org is known to be running.