### PR TITLE
buffer: Fix prefix of multiline messages

### DIFF
--- a/matrix/buffer.py
+++ b/matrix/buffer.py
@@ -500,7 +500,14 @@ class WeechatChannelBuffer(object):
         tags = tags or []
 
         tags_string = ",".join(tags)
-        W.prnt_date_tags(self._ptr, date, tags_string, data)
+
+        for line in self._multiline_split(data):
+            W.prnt_date_tags(self._ptr, date, tags_string, line)
+
+    def _multiline_split(self, data):
+        prefix, tab, msg = data.partition("\t")
+        for line in msg.split("\n"):
+            yield prefix + tab + line
 
     def error(self, string):
         # type: (str) -> None


### PR DESCRIPTION
This primarily fixes alignment of multiline messages when
weechat.look.prefix_align is set to "none". Messages without prefix
would otherwise be aligned with the nickname instead of being aligned
with the message.

Example before:

    20:20:00 <abcdefg> > In reply to @xyz:matrix.org
    20:20:00 > Lorem ipsum dolor sit amet, consectetur adipiscing elit.
    20:20:00 Sed accumsan nisi vel vestibulum hendrerit.
    20:21:00 <xyz> Cras a lacus libero.

Example after the fix:

    20:20:00 <abcdefg> > In reply to @xyz:matrix.org
    20:20:00 <abcdefg> > Lorem ipsum dolor sit amet, consectetur adipiscing elit.
    20:20:00 <abcdefg> Sed accumsan nisi vel vestibulum hendrerit.
    20:21:00 <xyz> Cras a lacus libero.

With weechat.look.prefix_align being set to the default "right", the
additional lines would be printed prefixed with "<>" and
weechat.look.{prefix_same_nick,prefix_same_nick_middle} weren't taken
into account. Now they are.