### PR TITLE
Use the full path when reading in EncryptedUpload

### DIFF
--- a/contrib/matrix_upload.py
+++ b/contrib/matrix_upload.py
@@ -113,7 +113,7 @@ class EncryptedUpload(Upload):
         self.source_mimetype = self.mimetype
         self.mimetype = "application/octet-stream"
 
-        with open(self.filename, "rb") as file:
+        with open(self.file, "rb") as file:
             self.ciphertext, self.file_keys = encrypt_attachment(file.read())
 
     def send_progress(self):


### PR DESCRIPTION
Calling ``matrix_upload.py --encrypt`` with a filename outside of the
current directory fails due to a typo in EncryptedUpload which uses the
basename of the file instead of the original/full path.