### PR TITLE
Ignore own messages without room_id

### DIFF
--- a/matrix/server.py
+++ b/matrix/server.py
@@ -1231,6 +1231,9 @@ class MatrixServer(object):
         server_buffer_prnt(self, pprint.pformat(message.response.body))
 
     def handle_own_messages_error(self, response):
+        if response.room_id not in self.room_buffers:
+            return
+
         room_buffer = self.room_buffers[response.room_id]
 
         if response.uuid not in room_buffer.printed_before_ack_queue:


### PR DESCRIPTION
I got this backtrace:

Traceback (most recent call last):
  File ".weechat/python/matrix/utf.py", line 89, in wrapper
    return function(*args, **kwargs)
  File ".weechat/python/autoload/matrix.py", line 343, in receive_cb
    server.handle_response(response)
  File ".weechat/python/matrix/server.py", line 1621, in handle_response
    self.handle_error_response(response)
  File ".weechat/python/matrix/server.py", line 1591, in handle_error_response
    self.handle_own_messages_error(response)
  File ".weechat/python/matrix/server.py", line 1234, in handle_own_messages_error
    room_buffer = self.room_buffers[response.room_id]
KeyError: ''

Not sure if ignoring is the best solution but probably better then
throwing an exception.