### PR TITLE
pyproject.toml: only require 'future' for python <3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ python = "^3.6"
 pyOpenSSL = "^19.1.0"
 webcolors = "^1.11.1"
 atomicwrites = "^1.3.0"
-future = "^0.18.2"
+future = { version = "^0.18.2", python = "<3.2" }
 attrs = "^19.3.0"
 logbook = "^1.5.3"
 pygments = "^2.6.1"


### PR DESCRIPTION
Commit 69cbba8839ad68420d55bd56833eb3e970ee6311 ("Only require 'future' for python <3.2") should be reflected by `pyproject.toml` as well.