### PR TITLE
buffer: Add signal to display name workarounds.

### DIFF
--- a/matrix/buffer.py
+++ b/matrix/buffer.py
@@ -1073,6 +1073,7 @@ class RoomBuffer(object):
                 user.user_id.startswith("@whatsapp_") or
                 user.user_id.startswith("@facebook_") or
                 user.user_id.startswith("@telegram_") or
+                user.user_id.startswith("@signal_") or
                 user.user_id.startswith("@_telegram_") or
                 user.user_id.startswith("@_xmpp_") or
                 user.user_id.startswith("@irc_")):


### PR DESCRIPTION
I'm using the [mautrix signal bridge](https://github.com/mautrix/signal) hosted on element, and I was not getting display names for signal contacts in weechat. This seems to solve the issue at least on my machine.