### PR TITLE
commands: Add /query support, to create a private chat with another user

### DIFF
--- a/main.py
+++ b/main.py
@@ -74,7 +74,7 @@ from matrix.commands import (hook_commands, hook_key_bindings, hook_page_up,
                              matrix_olm_command_cb, matrix_devices_command_cb,
                              matrix_room_command_cb, matrix_uploads_command_cb,
                              matrix_upload_command_cb, matrix_send_anyways_cb,
-                             matrix_reply_command_cb,
+                             matrix_reply_command_cb, matrix_query_command_cb,
                              matrix_cursor_reply_signal_cb)
 from matrix.completion import (init_completion, matrix_command_completion_cb,
                                matrix_debug_completion_cb,

--- a/matrix/buffer.py
+++ b/matrix/buffer.py
@@ -32,6 +32,7 @@ from nio import (
     RedactedEvent,
     RedactionEvent,
     RoomAliasEvent,
+    RoomCreateEvent,
     RoomEncryptionEvent,
     RoomMemberEvent,
     RoomMessage,
@@ -748,6 +749,9 @@ class WeechatChannelBuffer(object):
         tags = self._message_tags(user, "invite")
         message = self._membership_message(user, "invite")
         self.print_date_tags(message, date, tags + (extra_tags or []))
+
+    def display(self):
+        W.buffer_set(self._ptr, "display", "1")
 
     def remove_user_from_nicklist(self, user):
         # type: (WeechatUser) -> None
@@ -1541,6 +1545,9 @@ class RoomBuffer(object):
             self.print_megolm(event, extra_tags)
 
         elif isinstance(event, UnknownEvent):
+            pass
+
+        elif isinstance(event, RoomCreateEvent):
             pass
 
         elif isinstance(event, BadEvent):

--- a/matrix/server.py
+++ b/matrix/server.py
@@ -59,6 +59,7 @@ from nio import (
     DeleteDevicesAuthResponse,
     DeleteDevicesResponse,
     TransportType,
+    RoomCreateResponse,
     RoomMessagesResponse,
     RoomMessagesError,
     EncryptionError,
@@ -1651,6 +1652,14 @@ class MatrixServer(object):
         elif isinstance(response, DeleteDevicesResponse):
             self.info("Device successfully deleted")
 
+        elif isinstance(response, RoomCreateResponse):
+            try:
+                buffer = self.find_room_from_id(response.room_id)
+            except KeyError:
+                self.create_room_buffer(response.room_id, self.next_batch)
+                buffer = self.find_room_from_id(response.room_id)
+            buffer.weechat_buffer.display()
+
         elif isinstance(response, KeysQueryResponse):
             self.keys_queried = False
             W.bar_item_update("buffer_modes")
@@ -1766,6 +1775,10 @@ class MatrixServer(object):
         self.room_buffers[room_id] = buf
         self.buffers[room_id] = buf.weechat_buffer._ptr
 
+    def create_private_messaging_room(self, user_id):
+        _, request = self.client.room_create(is_direct=True, invite={user_id})
+        self.send_or_queue(request)
+
     def find_room_from_ptr(self, pointer):
         try:
             room_id = key_from_value(self.buffers, pointer)
@@ -1778,6 +1791,15 @@ class MatrixServer(object):
     def find_room_from_id(self, room_id):
         room_buffer = self.room_buffers[room_id]
         return room_buffer
+
+    def find_room_from_user_id(self, user_id):
+        for room_buffer in self.room_buffers.values():
+            if (room_buffer.weechat_buffer.type == "private" and
+                    len(room_buffer.weechat_buffer.users) <= 2):
+                user_ids = [
+                    u.host for u in room_buffer.weechat_buffer.users.values()]
+                if self.user_id and user_id in user_ids:
+                    return room_buffer
 
     def garbage_collect_users(self):
         """ Remove inactive users.

--- a/matrix/server.py
+++ b/matrix/server.py
@@ -45,6 +45,7 @@ from nio import (
     LocalProtocolError,
     LoginResponse,
     LoginInfoResponse,
+    JoinedRoomsResponse,
     Response,
     Rooms,
     RoomSendResponse,
@@ -1636,6 +1637,17 @@ class MatrixServer(object):
 
         elif isinstance(response, RoomSendResponse):
             self.handle_own_messages(response)
+
+        elif isinstance(response, JoinedRoomsResponse):
+            for room_id in response.rooms:
+                try:
+                    self.find_room_from_id(room_id)
+                except KeyError:
+                    self.create_room_buffer(room_id, self.next_batch)
+
+            if len(response.rooms) == 1:
+                buffer = self.find_room_from_id(response.rooms[0])
+                buffer.weechat_buffer.display()
 
         elif isinstance(response, RoomMessagesResponse):
             self.handle_backlog_response(response)


### PR DESCRIPTION
Support initiating chats with other users using /query command.

When inside a matrix channel or server user id can be in the form:
 -`@user:server.ext`
 - `user:server.ext`
 - `@user` (it looks for `@user:current-server.ext`)
 - `user` (it looks for `@user:current-server.ext`)

When inside a channel, can be just the nickname of the user, and we'll
figure out the corresponding id.

Re-initiating a left chat is supported, but may need some fixes.