### PR TITLE
Switch to correct build-system definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,5 @@ matrix_sso_helper = ["aiohttp"]
 matrix_upload = ["python-magic", "requests"]
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
pyproject.toml:
Use the correct PEP517 build-backend, as defined by poetry upstream (https://python-poetry.org/docs/pyproject#poetry-and-pep-517).