### PR TITLE
fix: add heisenbridge default shortname from ansible role

### DIFF
--- a/matrix/buffer.py
+++ b/matrix/buffer.py
@@ -1076,7 +1076,8 @@ class RoomBuffer(object):
                 user.user_id.startswith("@signal_") or
                 user.user_id.startswith("@_telegram_") or
                 user.user_id.startswith("@_xmpp_") or
-                user.user_id.startswith("@irc_")):
+                user.user_id.startswith("@irc_") or
+                user.user_id.startswith("@hbirc_")):
             if user.display_name:
                 short_name = user.display_name[0:50]
         elif user.user_id.startswith("@twilio_"):


### PR DESCRIPTION
Adds the default shortname for heisenbridge when heisenbridge in installed from https://github.com/spantaleev/matrix-docker-ansible-deploy/

Signed-off-by: gardar <gardar@users.noreply.github.com>