### PR TITLE
Add cffi dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ matrix-nio[e2e]>=0.18.7
 aiohttp ; python_version >= "3.5"
 python-magic
 requests
+cffi


### PR DESCRIPTION
On a freshly installed Ubuntu 22.04 pip install --user -r requirements.txt fails without cffi pip package