### PR TITLE
Fix compatibility with matrix-nio 0.21

### DIFF
--- a/matrix/config.py
+++ b/matrix/config.py
@@ -24,11 +24,10 @@ To add configuration options refer to MatrixConfig.
 Server specific configuration options are handled in server.py
 """
 
+import logging
 from builtins import super
 from collections import namedtuple
 from enum import IntEnum, Enum, unique
-
-import logbook
 
 import nio
 from matrix.globals import SCRIPT_NAME, SERVERS, W
@@ -57,9 +56,8 @@ class NewChannelPosition(IntEnum):
     NEXT = 1
     NEAR_SERVER = 2
 
-
-nio.logger_group.level = logbook.ERROR
-
+nio_logger = logging.getLogger("nio")
+nio_logger.setLevel(logging.ERROR)
 
 class Option(
     namedtuple(
@@ -141,18 +139,13 @@ def change_log_level(category, level):
     Called every time the user changes the log level or log category
     configuration option."""
 
+    if category == "encryption":
+        category = "crypto"
+
     if category == "all":
-        nio.logger_group.level = level
-    elif category == "http":
-        nio.http.logger.level = level
-    elif category == "client":
-        nio.client.logger.level = level
-    elif category == "events":
-        nio.events.logger.level = level
-    elif category == "responses":
-        nio.responses.logger.level = level
-    elif category == "encryption":
-        nio.crypto.logger.level = level
+        nio_logger.setLevel(level)
+    else:
+        nio_logger.getChild(category).setLevel(level)
 
 
 @utf8_decode
@@ -178,7 +171,7 @@ def config_log_level_cb(data, option):
 @utf8_decode
 def config_log_category_cb(data, option):
     """Callback for the network.debug_category option."""
-    change_log_level(G.CONFIG.debug_category, logbook.ERROR)
+    change_log_level(G.CONFIG.debug_category, logging.ERROR)
     G.CONFIG.debug_category = G.CONFIG.network.debug_category
     change_log_level(
         G.CONFIG.network.debug_category, G.CONFIG.network.debug_level
@@ -203,20 +196,20 @@ def config_pgup_cb(data, option):
     return 1
 
 
-def level_to_logbook(value):
+def level_to_logging(value):
     if value == 0:
-        return logbook.ERROR
+        return logging.ERROR
     if value == 1:
-        return logbook.WARNING
+        return logging.WARNING
     if value == 2:
-        return logbook.INFO
+        return logging.INFO
     if value == 3:
-        return logbook.DEBUG
+        return logging.DEBUG
 
-    return logbook.ERROR
+    return logging.ERROR
 
 
-def logbook_category(value):
+def logging_category(value):
     if value == 0:
         return "all"
     if value == 1:
@@ -647,7 +640,7 @@ class MatrixConfig(WeechatConfig):
                 0,
                 "error",
                 "Enable network protocol debugging.",
-                level_to_logbook,
+                level_to_logging,
                 config_log_level_cb,
             ),
             Option(
@@ -658,7 +651,7 @@ class MatrixConfig(WeechatConfig):
                 0,
                 "all",
                 "Debugging category",
-                logbook_category,
+                logging_category,
                 config_log_category_cb,
             ),
             Option(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ atomicwrites
 attrs
 logbook
 pygments
-matrix-nio[e2e]>=0.18.7
+matrix-nio[e2e]>=0.21.0
 aiohttp ; python_version >= "3.5"
 python-magic
 requests


### PR DESCRIPTION
The 0.20.0 made a breaking change in how they handle logging, moving off logbook to the standard logging module, breaking weechat-matrix's config module.

This patch adresses the API change (without migrating ourselves to logboox), and bumps the matrix-nio requirements to reflect the dependency on the new API.